### PR TITLE
Fixed a logical mistake in bank-transfer example

### DIFF
--- a/docs/intro/conceptual-overview.rst
+++ b/docs/intro/conceptual-overview.rst
@@ -14,7 +14,7 @@ Imagine we're building a wire transfer service for a bank. Users can make transf
 .. code-block::
 
   def transfer(from, to, amount)
-    if (from.balance <= amount) # guard
+    if (from.balance >= amount) # guard
       from.balance -= amount;   # withdraw
       to.balance += amount;     # deposit
 


### PR DESCRIPTION
A bank must _not_ transfer money from an account whose balance is lower
than the amount being transferred.