### PR TITLE
Fix typo in found states number in constants.rst

### DIFF
--- a/docs/core/constants.rst
+++ b/docs/core/constants.rst
@@ -113,7 +113,7 @@ We can also assign constants to sets of model values. Put it in as a normal set,
   S <- [model value] {s1, s2, s3, s4, s5}
 
 
-Sets of model values will become *extremely* useful when we start modeling :doc:`concurrency <concurrency>`, but there's still one cool trick we can do with them right now. If you run the model with that value of ``S``, you will get 4,735 states total— the same as if you did ``S <- 1..5``. But notice this other option below the "set of model values" bar:
+Sets of model values will become *extremely* useful when we start modeling :doc:`concurrency <concurrency>`, but there's still one cool trick we can do with them right now. If you run the model with that value of ``S``, you will get 4,375 states total— the same as if you did ``S <- 1..5``. But notice this other option below the "set of model values" bar:
 
 .. image:: img/symmetry_set.png
 


### PR DESCRIPTION
There's a typo in the number of states for the set of model values.