### PR TITLE
fix: typos

### DIFF
--- a/docs/core/pluscal.rst
+++ b/docs/core/pluscal.rst
@@ -74,7 +74,7 @@ Which brings us to labels. Labels represent everything that can happen in a sing
 I am saying that the summation happens in a single step, and no time passes between the start and end of the summation. By contrast, if I write
 
 ::
-  
+
   SendRequest:
     \* blah blah blah
   GetResponse:
@@ -82,7 +82,7 @@ I am saying that the summation happens in a single step, and no time passes betw
 
 Then *time passes* between ``SendRequest`` and ``GetResponse``.
 
-.. note:: The labels represent the titular "actions" in the *Temporal Logic of Actions*. 
+.. note:: The labels represent the titular "actions" in the *Temporal Logic of Actions*.
 
 If I wanted to, I could *choose* to make the summation nonatomic. Here's how I'd do it in PlusCal:
 
@@ -93,7 +93,7 @@ If I wanted to, I could *choose* to make the summation nonatomic. Here's how I'd
       x := x + seq[i];
       i := i + 1;
     end while;
-    
+
 .. todo:: {GV} Diagram of the different times
 
 We'll talk about the nuances of `while` later, but the basic idea is that now *each iteration* of the summation is nonatomic. We could add two numbers, start an http request, add two more, receive the response, and add the rest. Or we could add them all before both steps of the http, or all after. Concurrency is weird.
@@ -105,7 +105,7 @@ Label Rules
 
 We're modeling time here, so there are restrictions on where we can place the labels. We'll recap all of the label rules `at the end <label_rules_summary>`.
 
-First, **all statements must belong to a label.** This means, among other things, that you miust always start the algorithm with a label.
+First, **all statements must belong to a label.** This means, among other things, that you must always start the algorithm with a label.
 
 Second, **any variable can only be updated once per label.** Remember, each label only represents one single instant of time. If the variable is updated twice, that means it's gone through two separate values in a single instant of time, meaning... it's not an instant of time anymore.
 
@@ -130,7 +130,7 @@ The rest of the label rules relate to *specific* constructs in PlusCal, so let's
 PlusCal expressions
 -------------------
 
-In addition to updates, there are three other statement-level constructs: 
+In addition to updates, there are three other statement-level constructs:
 
 .. index:: skip, assert, goto
 .. _goto:
@@ -184,7 +184,7 @@ If ``bool`` is true, then  ``x := 1`` would happen as part of label B. But if ``
 
 .. warning:: A common misunderstanding I see in beginners is thinking the B label is *nested in* the A label, like we're in both at the same time. This isn't how it works: we stop being in the A label as soon as we enter the B label. A better mental model is that since ``B:`` is inside a condition from ``A:``, the B label is only *reachable* from A.
 
-Not all blocks have to have the *same* number of labels! Conditionals trigger different behavior, which can take different amounts of time. If you have a lot of 
+Not all blocks have to have the *same* number of labels! Conditionals trigger different behavior, which can take different amounts of time. If you have a lot of
 
 .. index:: macro
 .. _macro:
@@ -249,12 +249,12 @@ while
 A Duplication Checker
 ======================
 
-Now that we know the basics of PlusCal, let's apply it to a small problem. I like to start with simple array algorithms, because we already have the tools to specify them. First we write an operator that expresses the high-level goal of the algorithm, then we write the algorithm, then we verify the algorithm matches the operator. 
+Now that we know the basics of PlusCal, let's apply it to a small problem. I like to start with simple array algorithms, because we already have the tools to specify them. First we write an operator that expresses the high-level goal of the algorithm, then we write the algorithm, then we verify the algorithm matches the operator.
 
 For example, if we were writing an algorithm to check if ``seq`` has any duplicate elements, the operator might be ``IsUnique(seq)``, and then the algorithm could work like this:
 
 1. Create an empty set ``seen``, then step through the elements of ``seq``.
-2. Every time we see a number, we check if it's already in ``seen``. 
+2. Every time we see a number, we check if it's already in ``seen``.
 
     * If it is, we say the list is not unique.
     * Otherwise, we add the element to ``seen`` and continue.
@@ -292,7 +292,7 @@ I know this completed successfully because otherwise a big error bar would have 
 
   5. How many states TLC knows *for certain* it'll have to check. Some of these states will add more states to check, and so on and so forth.
 
-6. TLC stores explored states as hashes, this is the chance that there's a hash collision. In practice this never goes above one in a million billion and can be ignored. 
+6. TLC stores explored states as hashes, this is the chance that there's a hash collision. In practice this never goes above one in a million billion and can be ignored.
 
 7. How often each label was run and how many states that lead to. If one label has 0 states then there's probably a bug in your spec.
 
@@ -300,7 +300,7 @@ I know this completed successfully because otherwise a big error bar would have 
   :caption: Four iterate loops, plus Initial and Done states, makes 6 distinct states.
 
   edge[arrowhead=vee];
-  
+
   I1 [label="i=1\nseq[i]=1"];
   I2 [label="i=2\nseq[i]=2"];
   I3 [label="i=3\nseq[i]=3"];
@@ -309,7 +309,7 @@ I know this completed successfully because otherwise a big error bar would have 
   I1 -> I2 -> I3 -> I4;
 
 
-To make sure that you're following properly, you can check that that you got the same number of states and distinct states I did. In my case, I got :ss:`duplicates_fixed_input`; you should see that too. If you get a different number, you may have made a mistake in transcribing the spec. The states and distinct states make a partial "fingerprint" of the model. Going forward, whenever I show a spec, I'll list the states and distinct states of the model check under the code listing. 
+To make sure that you're following properly, you can check that that you got the same number of states and distinct states I did. In my case, I got :ss:`duplicates_fixed_input`; you should see that too. If you get a different number, you may have made a mistake in transcribing the spec. The states and distinct states make a partial "fingerprint" of the model. Going forward, whenever I show a spec, I'll list the states and distinct states of the model check under the code listing.
 
 .. note:: You'll get a different number than me if the spec *fails*, because TLC will terminate execution early. In that case, I will note that the modelcheck should fail when showing the code listing.
 
@@ -325,7 +325,7 @@ To check both, we can use multiple starting states. TLA+ doesn't just let us ass
 .. spec:: duplicates/2/duplicates.tla
   :diff: duplicates/1/duplicates.tla
 
-The model checker will now check *both* ``<<1, 2, 3, 2>>`` and ``<1, 2, 3, 4>>`` as the value of ``seq``. More specifically, does two complete runs, one for each possible value. If either complete run, or :dfn:`behavior`, would lead to an error, TLC will let us know. 
+The model checker will now check *both* ``<<1, 2, 3, 2>>`` and ``<1, 2, 3, 4>>`` as the value of ``seq``. More specifically, does two complete runs, one for each possible value. If either complete run, or :dfn:`behavior`, would lead to an error, TLC will let us know.
 
 .. figure:: graphs/duplicates_2.gv.png
 
@@ -349,7 +349,7 @@ We might think, with 1000 initial states and 2 labels, there will be 3,000 total
 10,000 starting states
 ----------------------
 
-So now we're testing two inputs. That's twice as good as one input. Even better than that would be testing 10,000 inputs. Remember how in the last chapter we talked about generating `sets of values <sets_of_values>`? This is just one of the many places it's really useful. 
+So now we're testing two inputs. That's twice as good as one input. Even better than that would be testing 10,000 inputs. Remember how in the last chapter we talked about generating `sets of values <sets_of_values>`? This is just one of the many places it's really useful.
 
 
 .. spec:: duplicates/3/duplicates.tla
@@ -362,7 +362,7 @@ We're now significantly more likely to cover all interesting edge cases. This is
 
 Now that we have broad state-space coverage, it's time to write some properties. In :doc:`the next chapter <invariants>` we'll specify that our checker always gets the correct result.
 
-.. todo:: {UPDATE} This is the right place to talk about unbound models. 
+.. todo:: {UPDATE} This is the right place to talk about unbound models.
 
 Summary
 =========
@@ -370,7 +370,7 @@ Summary
 - Specifications have variables. These can either be a fixed value (using ``=``) or an element in a set (using ``\n``. Any TLC value can be a variable.
 
   - If an element of a set, then TLC will test the model on *every possible starting state*.
-- PlusCal is a language that makes writing specifications easier. 
+- PlusCal is a language that makes writing specifications easier.
 
   - In the PlusCal algorithm body, variables are updated with ``:=``. ``=`` is comparison.
 

--- a/docs/core/setup.rst
+++ b/docs/core/setup.rst
@@ -92,7 +92,7 @@ I often like to test the outputs of operators without having to run the entire s
   Eval == 0
   ====
 
-This is different from a normal TLA+ file in two ways. First, instead of having "What is the behavior spec" set to "Temporal formula", I have it set to "no behavior spec". Second, on the "model checking results" page, I put put ``Eval`` in the "Evaluate Constant Expression Box".
+This is different from a normal TLA+ file in two ways. First, instead of having "What is the behavior spec" set to "Temporal formula", I have it set to "no behavior spec". Second, on the "model checking results" page, I put ``Eval`` in the "Evaluate Constant Expression Box".
 
 .. figure:: img/setup/scratch_eval.png
 
@@ -105,7 +105,7 @@ Now whenever I run the model, the output of ``Eval`` will be put on the box to t
 
 Now running ``Eval`` will put "hello world!".
 
-.. index:: >>> 
+.. index:: >>>
 .. _>>>_notation:
 
 Having a scratchfile is very useful and I recommend setting one up. In the guide itself I will occasionally post "expression evaluations" like this

--- a/docs/core/setup.rst
+++ b/docs/core/setup.rst
@@ -92,7 +92,7 @@ I often like to test the outputs of operators without having to run the entire s
   Eval == 0
   ====
 
-This is different from a normal TLA+ file in two ways. First, instead of having "What is the behavior spec" set to "Temporal formula", I have it set to "no behavior spec". Second, on the "model checking results" page, I put ``Eval`` in the "Evaluate Constant Expression Box".
+This is different from a normal TLA+ file in two ways. First, instead of having "What is the behavior spec" set to "Temporal formula", I have it set to "no behavior spec". Second, on the "model checking results" page, I put ``Eval`` in the "Evaluate Constant Expression" box.
 
 .. figure:: img/setup/scratch_eval.png
 

--- a/docs/intro/faq.rst
+++ b/docs/intro/faq.rst
@@ -7,7 +7,7 @@ These are some of the questions I get regularly asked about TLA+. If you have on
 What's TLA+?
 =================
 
-TLA+ is a language for writing and checking "specifications", or system designs. Once you have your specification, you can then test the specification *directly* for bugs, even before you've written any code. 
+TLA+ is a language for writing and checking "specifications", or system designs. Once you have your specification, you can then test the specification *directly* for bugs, even before you've written any code.
 
 Who made it?
 ------------
@@ -27,7 +27,7 @@ I've heard that TLA+ is a "formal method". What's that?
 
 "Formal methods" is, very roughly, the field of computer science dedicated to writing correct programs. This is usually done by first writing a rigorous mathematical definition of what "correct" means ("formal specification"), and then showing that the code satisfies that definition ("formal verification"). You can see what this process looks like in practice at `Let's Prove Leftpad`_, which is another project I run.
 
-You don't see formal verification a lot because it's *really, really hard.* There's just too many complicated things in general-purpose code. One way to get around this is to focus on verifying a much simpler domain, like abstract designs. That's what TLA+ does, making it easier to use at the cost of losting some power. 
+You don't see formal verification a lot because it's *really, really hard.* There's just too many complicated things in general-purpose code. One way to get around this is to focus on verifying a much simpler domain, like abstract designs. That's what TLA+ does, making it easier to use at the cost of losing some power.
 
 How does TLA+ test specifications?
 ==================================
@@ -56,7 +56,7 @@ Yes! Here are just a few of the (public!) successful use cases:
 
 * `Amazon Web Services`_ used TLA+ to model parts of S3 and DynamoDB, finding a 35-step bug that escaped all their tests and two code reviews.
 
-* `Crowdstrike`_ found multiple failure cases over just five days of workshops. 
+* `Crowdstrike`_ found multiple failure cases over just five days of workshops.
 
 TLA+ has also been used by Azure, MongoDB, Confluent, Elastic, and Cockroach Labs to find bugs.
 
@@ -72,10 +72,10 @@ What's TLA+ bad for?
 
 Like any tool, TLA+ has limitations. Aside from the obvious one (can't test your code), there are some TLA+ weak spots:
 
-- Numerical code. TLA+ supports integers but not decimals or floating-point. 
+- Numerical code. TLA+ supports integers but not decimals or floating-point.
 - String manipulation. You can represent strings as a sequence of characters for basic manipulation, but it gets awkward.
 - Probabilistic properties. You can say "X definitely happens" or "X never happens", but not "X happens at least 90% of the time". There are `special tools`_ for checking those kinds of properties.
-- Reachability properties. You can't say "it's always *possible* for X to eventually happen, even if it doesn't *have* to happen." 
+- Reachability properties. You can't say "it's always *possible* for X to eventually happen, even if it doesn't *have* to happen."
 - Realtime properties, like "If Y happens, X has to happen within five real actual seconds".
 
 There's also some limitations to the current tooling. There's not yet official features for interactive spec exploration or visualization.
@@ -83,7 +83,7 @@ There's also some limitations to the current tooling. There's not yet official f
 Do I need a strong math background to use TLA+?
 ===============================================
 
-TLA+ does use a bit of math that's not often used in regular programming, but it's all learnable as you go. The |core| gradually explains it as you go along. 
+TLA+ does use a bit of math that's not often used in regular programming, but it's all learnable as you go. The |core| gradually explains it as you go along.
 
 (If you want to know what to expect, the new math concepts are the boolean statement "X implies Y" and the set quantifiers "forall/some x in set".)
 
@@ -121,7 +121,7 @@ These are all about formally verifying code; you can see examples of what they a
   Isabelle/Agda/Coq/Lean?
         ---
 
-  These are all "theorem provers". They're 
+  These are all "theorem provers". They're
 
   (TLA+ also has a theorem prover, called `TLAPS <tlaps>`.)
 
@@ -131,7 +131,7 @@ These are all about formally verifying code; you can see examples of what they a
 Alloy/Spin/Event-B/mCRL2?
 -------------------------
 
-Now we're getting into the hard stuff. These are all other formal specification languages with the same domain as TLA+: verifying abstract designs instead of working code. They're close enough for the subtle tradeoffs to matter. In my opinion, any comparisons of these tools needs to be be its own page, written by experts in both languages. 
+Now we're getting into the hard stuff. These are all other formal specification languages with the same domain as TLA+: verifying abstract designs instead of working code. They're close enough for the subtle tradeoffs to matter. In my opinion, any comparisons of these tools needs to be be its own page, written by experts in both languages.
 
 
 P?


### PR DESCRIPTION
It also removes some trailing whitespace, if you want I can make the change *only* be the typos.
For reference:
- miust -> must (https://github.com/hwayne/learntla-v2/pull/22/files#diff-cf16a1a84b8a56327cb824e4f04197c7102386c0e4a86958911c445185875886L108-R108)
- losting -> losing (https://github.com/hwayne/learntla-v2/pull/22/files#diff-b654c7171df8af611b61e69b8ac2a7557ea077d2a35f3b607641b0feb6a3c975L30-R30)
- "put put" -> "put" & ""Evaluate Constant Expression Box"" -> ""Evaluate Constant Expression" Box" (https://github.com/hwayne/learntla-v2/pull/22/files#diff-992539f166e285f30638a8033484b7456c74c2ea601d6000ded772191500a4ebL95-R95)