### PR TITLE
fix typo in Sequence section

### DIFF
--- a/docs/core/operators.rst
+++ b/docs/core/operators.rst
@@ -175,7 +175,7 @@ There's also a ``Sequences`` module. If you ``EXTENDS Sequences``, you also get 
 
   * - Expression
     - Gives
-  * - ``Append(S, <<"b">>)``
+  * - ``Append(S, "b")``
     - ``<<"a", "b">>``
   * - ``S \o <<"b", "c">>``
     - ``<<"a", "b", "c">>``


### PR DESCRIPTION
This is a typo right? Because Append(S, <<"b">>) evaluates to <<"a", <<"b">>>>