### PR TITLE
fix inconsistencies in hourclock example

### DIFF
--- a/docs/core/tla.rst
+++ b/docs/core/tla.rst
@@ -23,7 +23,7 @@ I find the easiest way to explain what's going on with TLA+ is to relate it to w
 .. spec:: tla/hourclock_1/hourclock.tla
   :ss: hourclock_1
 
-You should be able to look at this spec and run it in your head. ``hr`` starts at some value between 1 and 12, and then increment, wrapping at 12 back to 1. The TLA+ translation *must* do the same thing. Let's take a look at it:
+You should be able to look at this spec and run it in your head. ``hr`` starts at 1, and then increment, wrapping at 12 back to 1. The TLA+ translation *must* do the same thing. Let's take a look at it:
 
 ::
 
@@ -44,7 +44,7 @@ You should be able to look at this spec and run it in your head. ``hr`` starts a
 
 First, we need to define the ``VARIABLES``, same way we define ``CONSTANTS``. Then there are operators: ``Init``, ``Next``, and ``Spec``. ``Spec`` is what we always put as "the temporal property to run", so that's the core of the TLA+ specification.
 
-In ``Next``, we've replaced ``hr := 0`` with ``hr' = 1``. As we learned in the :doc:`last chapter <action-properties>`, ``hr'`` is the value of ``hr`` in the *next* state. ``hr' = 1`` is a *boolean* statement, which is true or false. In fact, ``Next`` is a boolean operator: it's either true or false. It is true if it accurately describes the value of ``hr`` in the next state, and false if it does not.
+In ``Next``, we've replaced ``hr := 1`` with ``hr' = 1``. As we learned in the :doc:`last chapter <action-properties>`, ``hr'`` is the value of ``hr`` in the *next* state. ``hr' = 1`` is a *boolean* statement, which is true or false. In fact, ``Next`` is a boolean operator: it's either true or false. It is true if it accurately describes the value of ``hr`` in the next state, and false if it does not.
 
 So for these choices of ``<<hr, hr'>>``, ``Next`` is *true*:
 
@@ -92,7 +92,7 @@ Since ``Next`` is an action, to be "always true" it must always accurately descr
 
   .. code-block:: none
 
-    Init == x = 0
+    Init == x = 1
     Next == x' >= x
     Spec == Init /\ [][Next]_x
 

--- a/docs/specs/tla/hourclock_1/hourclock.tla
+++ b/docs/specs/tla/hourclock_1/hourclock.tla
@@ -1,6 +1,6 @@
 ---- MODULE hourclock ----
-\* TODO: two clocks
 EXTENDS Naturals
+\* TODO: two clocks
 (*--algorithm hourclock
 variable hr = 1; \* hour
 
@@ -9,7 +9,7 @@ begin
     while TRUE do
         if hr = 12 then
           hr := 1;
-        else       
+        else
             hr := hr + 1;
         end if;
     end while;

--- a/docs/specs/tla/hourclock_2/hourclock.tla
+++ b/docs/specs/tla/hourclock_2/hourclock.tla
@@ -10,7 +10,7 @@ begin
     while TRUE do
         if hr = 12 then
           hr := 1;
-        else       
+        else
             hr := hr + 1;
         end if;
     end while;

--- a/docs/specs/tla/hourclock_3/hourclock.tla
+++ b/docs/specs/tla/hourclock_3/hourclock.tla
@@ -11,7 +11,7 @@ begin
           hr := 1;
         else
           with x = 1 do       
-            hr := hr + 1;
+            hr := hr + x;
           end with
         end if;
     end while;

--- a/docs/specs/tla/hourclock_3/hourclock.tla
+++ b/docs/specs/tla/hourclock_3/hourclock.tla
@@ -10,9 +10,9 @@ begin
         if hr = 12 then
           hr := 1;
         else
-          with x = 1 do       
+          with x = 1 do
             hr := hr + x;
-          end with
+          end with;
         end if;
     end while;
 end algorithm; *)

--- a/docs/specs/tla/hourclock_4/hourclock.tla
+++ b/docs/specs/tla/hourclock_4/hourclock.tla
@@ -10,9 +10,9 @@ begin
         if hr = 12 then
           hr := 1;
         else
-          with x \in 1..2 do       
+          with x \in 1..2 do
             hr := hr + x;
-          end with
+          end with;
         end if;
     end while;
 end algorithm; *)

--- a/docs/specs/tla/hourclock_4/hourclock.tla
+++ b/docs/specs/tla/hourclock_4/hourclock.tla
@@ -10,8 +10,8 @@ begin
         if hr = 12 then
           hr := 1;
         else
-          with x \in 0..1 do       
-            hr := hr + 1;
+          with x \in 1..2 do       
+            hr := hr + x;
           end with
         end if;
     end while;

--- a/raw-specs/tla.xml
+++ b/raw-specs/tla.xml
@@ -13,8 +13,8 @@ begin
         if hr = 12 then
           hr := 1;
         else<s on="3-4">
-          with x<s on="3"> = 1</s><s on="4"> \in 0..1</s> do</s>
-            hr := hr + 1;<s on="3-4">
+          with x<s on="3"> = 1</s><s on="4"> \in 1..2</s> do</s>
+            hr := hr +<s on="1-2"> 1;</s><s on="3-4"> x;
           end with;</s>
         end if;
     end while;

--- a/raw-specs/tla/hourclock__1.tla
+++ b/raw-specs/tla/hourclock__1.tla
@@ -17,7 +17,7 @@ begin
     while TRUE do
         if hr = 12 then
           hr := 1;
-        else       
+        else
             hr := hr + 1;
         end if;
     end while;

--- a/raw-specs/tla/hourclock__2.tla
+++ b/raw-specs/tla/hourclock__2.tla
@@ -13,7 +13,7 @@ begin
     while TRUE do
         if hr = 12 then
           hr := 1;
-        else       
+        else
             hr := hr + 1;
         end if;
     end while;

--- a/raw-specs/tla/hourclock__3.tla
+++ b/raw-specs/tla/hourclock__3.tla
@@ -13,9 +13,9 @@ begin
         if hr = 12 then
           hr := 1;
         else
-          with x = 1 do       
-            hr := hr + 1;
-          end with
+          with x = 1 do
+            hr := hr + x;
+          end with;
         end if;
     end while;
 end algorithm; *)

--- a/raw-specs/tla/hourclock__4.tla
+++ b/raw-specs/tla/hourclock__4.tla
@@ -17,13 +17,13 @@ begin
         if hr = 12 then
           hr := 1;
         else
-          with x \in 0..1 do       
-            hr := hr + 1;
-          end with
+          with x \in 1..2 do
+            hr := hr + x;
+          end with;
         end if;
     end while;
 end algorithm; *)
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-224497c412c65f9e488bb9ea796850bb
+\* BEGIN TRANSLATION (chksum(pcal) = "d0081905" /\ chksum(tla) = "27d8122a")
 VARIABLE hr
 
 vars == << hr >>
@@ -33,11 +33,11 @@ Init == (* Global variables *)
 
 Next == IF hr = 12
            THEN /\ hr' = 1
-           ELSE /\ \E x \in 0..1:
-                     hr' = hr + 1
+           ELSE /\ \E x \in 1..2:
+                     hr' = hr + x
 
 Spec == /\ Init /\ [][Next]_vars
         /\ WF_vars(Next)
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-a0a7361d9883ce44feffc70b9ee56cb8
+\* END TRANSLATION 
 ====


### PR DESCRIPTION
I fixed some inconsistencies between specs and explanations I found in the hourclock example of the TLA+ section.