### PR TITLE
Feedback on WF and SF syntax

### DIFF
--- a/docs/core/tla.rst
+++ b/docs/core/tla.rst
@@ -356,20 +356,29 @@ Fairness is formally defined in TLA+ as follows::
 
 In English:
 
-* ``WF_x(A)``: If it is *eventually always* true that the A action *can happen* (in a way that changes v), then it *will* eventually happen (and change v).
-* ``SF_vars(A)``: If it is *always eventually* true that the A action *can happen* (in a way that changes v), then it *will* eventually happen (and change v).
+* ``WF_v(A)``: If it is *eventually always* true that the A action *can happen* (in a way that changes v), then it *will* eventually happen (and change v).
+* ``SF_v(A)``: If it is *always eventually* true that the A action *can happen* (in a way that changes v), then it *will* eventually happen (and change v).
 
 
 Fairness constraints are appended to the definition of ``Spec``. You can see this in the translation of our prior `strong fairness example <strong_fairness_spec>`::
 
-  Spec == /\ Init /\ [][Next]_vars
-          /\ \A self \in Threads : SF_vars(thread(self))
+  Spec == /\ Init /\ [][Next]_v
+          /\ \A self \in Threads : SF_v(thread(self))
 
 (Remember, ``Spec`` defines what *counts as a valid trace*. Fairness is an additional constraint, ruling out things like infinite stutters.)
 
 Notice that by writing ``\A self: SF_vars(self)``, we're effectively making every thread fair. If we instead wrote ``\E``, we'd be saying that at least one thread is fair, but the rest may be unfair. If both those conditions are syntactically intuitive to you, I'd say you fully understand how pure TLA+ works.
 
+.. troubleshooting::
 
+  If you get
+
+    Encountered "WF_" at line X, column Y
+  or
+    Encountered "SF_" at line X, column Y
+
+  It's because you try to redefine operator ``WF_var(A)`` or ``SF_var(A)`` whereas they are already taken keywords.
+  Also make sure `VARIABLES var` is declared before using ``SF/WF_var()``.
 
 .. _fairness_status_example:
 


### PR DESCRIPTION
- Consistent subscript on `SF` and `WF`
- Troubleshooting hints for accidentally redefining them in TLA+ (which I tried to do while learning)