### PR TITLE
Reference Sequence's definition from the Functions page.

### DIFF
--- a/docs/core/functions.rst
+++ b/docs/core/functions.rst
@@ -10,7 +10,7 @@ Structured Data
 Structures
 ============
 
-Sequences cover tuples and arrays, now we need something to represent string hashmaps. In TLA+, this is the struct:
+`Sequences <sequence>` cover tuples and arrays, now we need something to represent string hashmaps. In TLA+, this is the struct:
 
 ::
 


### PR DESCRIPTION
Several times I've been on the Functions page and found myself unable to remember where in the site sequences are defined. I debated linking all mentions of "sequence" to its definition, and opted to be Rather Conservative.