### PR TITLE
Fix BecomesNull argument in Action Properties example

### DIFF
--- a/docs/core/action-properties.rst
+++ b/docs/core/action-properties.rst
@@ -145,7 +145,7 @@ You *can* use helper actions in your action properties, so we could do something
   BecomesNull(x) == x' = NULL
 
   LockCantBeStolen ==
-     [][lock # NULL => BecomesNull(lock')]_lock
+     [][lock # NULL => BecomesNull(lock)]_lock
 
 Quantified Action Properties
 -----------------------------


### PR DESCRIPTION
The previous argument resulted in the following parser error:

> The level of argument 1 exceeds the maximum level allowed by the operator.

I'm just learning TLA+ so I cannot verify this, but looks reasonable from a pure functional evaluation semantic.