### PR TITLE
Update Apalache links to new site

### DIFF
--- a/docs/reference/other-resources.rst
+++ b/docs/reference/other-resources.rst
@@ -13,7 +13,7 @@ Learning Resources
 `TLA+ Video Course`_
   A video course by the inventor of TLA+.
 
-.. https://apalache.informal.systems/docs/idiomatic/index.html
+.. https://apalache-mc.org/docs/idiomatic/index.html
 
 `Introduction to Formal Pragmatic Modeling <https://elliotswart.github.io/pragmaticformalmodeling/>`__
   A fantastic dive into three large production-level specifications. Assumes some TLA+ knowledge.
@@ -69,7 +69,7 @@ Other Tooling
 
 .. _apalache:
 
-`Apalache <https://apalache.informal.systems/>`__
+`Apalache <https://apalache-mc.org/>`__
   An alternate model checker for TLA+. It uses symbolic model checking instead of enumerating all states. 
 
   (Disclosure, I'm currently doing some consulting work for Informal Systems.)

--- a/docs/topics/optimization.rst
+++ b/docs/topics/optimization.rst
@@ -388,7 +388,7 @@ You can also do this with :ref:`state <state_constraint>` and :ref:`action <acti
 Try Apalache
 ------------
 
-`Apalache <https://apalache.informal.systems/>`__ is an alternative model checker for TLA+. It doesn't `support the full language yet <https://apalache.informal.systems/docs/apalache/features.html>`__ but I've heard that it's faster on some kinds of specs. It also has a `type system <https://apalache.informal.systems/docs/tutorials/snowcat-tutorial.html>`__!
+`Apalache <https://apalache-mc.org/>`__ is an alternative model checker for TLA+. It doesn't `support the full language yet <https://apalache-mc.org/docs/apalache/features.html>`__ but I've heard that it's faster on some kinds of specs. It also has a `type system <https://apalache-mc.org/docs/tutorials/snowcat-tutorial.html>`__!
 
 Fiddle with JVM Arguments
 -------------------------


### PR DESCRIPTION
Apalache has apparently moved to https://apalache-mc.org/

The top-level old link https://apalache.informal.systems redirects appropriately, but links with paths are broken. 

This PR fixes the links to point to new site.